### PR TITLE
Add homebrew save type overrides

### DIFF
--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -197,9 +197,14 @@ static Result searchGameDb(u64 x, GameDbEntry *const db, s32 *const entryPos)
 
 static u16 checkSaveOverride(u32 gameCode)
 {
-	if((gameCode & 0xFFu) == 'F') // Classic NES Series.
+	switch (gameCode & 0xFFu)
 	{
-		return SAVE_TYPE_EEPROM_8k;
+		case '1': return SAVE_TYPE_EEPROM_64k;         // Homebrew using EEPROM.
+		case '2': return SAVE_TYPE_SRAM_256k;          // Homebrew using SRAM.
+		case '3': return SAVE_TYPE_FLASH_512k_PSC_RTC; // Homebrew using FLASH-64.
+		case '4': return SAVE_TYPE_FLASH_1m_MRX_RTC;   // Homebrew using FLASH-128.
+		case 'F': return SAVE_TYPE_EEPROM_8k;          // Classic NES Series.
+		case 'S': return SAVE_TYPE_SRAM_256k;          // Homebrew using SRAM (Butano games).
 	}
 
 	static const struct


### PR DESCRIPTION
The EverDrive GBA X5 firmware allows homebrew developers to force a certain save type using '1' to '4' as the first character of the Game Code in the ROM header.

From the OS [changelog](http://krikzz.com/pub/support/everdrive-gba/OS/changelist.txt):

> If ROM isn't exists in bram-db then first char of ROM ID can be used as save memory selector:
> 1 - EEPROM
> 2 - SRAM
> 3 - FLASH-64
> 4 - FLASH-128
> Number should be stored as char, eg 1 equal to 0x31 in hex format

In addition, games using the [Butano](https://github.com/GValiente/butano) engine are currently using 'S' as the first character (I guess they saw the proposal in the [Twitter thread](https://twitter.com/exelotl/status/1322651844443885579) but not the eventual changelog entry).

This PR adds detection for these to open_agb_firm, to make it play nicely with modern homebrew.

Maybe once https://github.com/profi200/open_agb_firm/issues/9 is done, SRAM should also become the default for unrecognised games?