### PR TITLE
(WIP) Improved Sleep Mode

### DIFF
--- a/include/arm11/hardware/codec.h
+++ b/include/arm11/hardware/codec.h
@@ -46,6 +46,10 @@ void CODEC_deinit(void);
  */
 void CODEC_wakeup(void);
 
+void CODEC_muteI2S(void);
+
+void CODEC_unmuteI2S(void);
+
 /**
  * @brief      Get raw ADC data for Circle-Pad/Touchscreen.
  *

--- a/include/arm11/hardware/lcd.h
+++ b/include/arm11/hardware/lcd.h
@@ -147,5 +147,6 @@ typedef enum
 u8 LCDI2C_readReg(u8 lcd, LcdI2cReg reg);
 void LCDI2C_writeReg(u8 lcd, LcdI2cReg reg, u8 data);
 void LCDI2C_init(void);
+void LCDI2C_deinit(void);
 void LCDI2C_waitBacklightsOn(void);
 u16 LCDI2C_getRevisions(void);

--- a/include/arm9/arm7_stub.h
+++ b/include/arm9/arm7_stub.h
@@ -25,6 +25,9 @@
 noreturn void _a7_overlay_stub(void);
 extern const u32 _a7_overlay_stub_size[];
 
+noreturn void _a7_overlay_stub_capture(void);
+extern const u32 _a7_overlay_stub_capture_size[];
+
 noreturn void _a7_stub_start(void);
 extern u16 _a7_stub9_swi[]; // Final ARM9 mem location.
 extern const u32 _a7_stub_size[];

--- a/include/arm9/debug.h
+++ b/include/arm9/debug.h
@@ -24,4 +24,4 @@
 
 noreturn void panic();
 noreturn void panicMsg(const char *msg);
-//void dumpMem(u8 *mem, u32 size, char *filepath);
+void dumpMem(u8 *mem, u32 size, char *filepath);

--- a/include/hardware/lgy.h
+++ b/include/hardware/lgy.h
@@ -125,8 +125,11 @@ Result LGY_prepareGbaMode(bool biosIntro, u16 saveType, const char *const savePa
 Result LGY_setGbaRtc(const GbaRtc rtc);
 Result LGY_getGbaRtc(GbaRtc *const out);
 Result LGY_backupGbaSave(void);
+void LGY_sleepGba(void);
+void LGY_wakeGba(void);
 #ifdef ARM11
 void LGY_switchMode(void);
 void LGY_handleOverrides(void);
 void LGY_deinit(void);
+int LGY_isSleeping(void);
 #endif

--- a/include/ipc_handler.h
+++ b/include/ipc_handler.h
@@ -63,6 +63,8 @@ typedef enum
 	IPC_CMD9_SET_GBA_RTC       = MAKE_CMD9(0, 0, 2),
 	IPC_CMD9_GET_GBA_RTC       = MAKE_CMD9(0, 1, 0),
 	IPC_CMD9_BACKUP_GBA_SAVE   = MAKE_CMD9(0, 0, 0),
+	IPC_CMD9_SLEEPGBA          = MAKE_CMD9(0, 0, 0),
+	IPC_CMD9_WAKEGBA           = MAKE_CMD9(0, 0, 0),
 
 	// Miscellaneous API.
 	IPC_CMD9_PREPARE_POWER     = MAKE_CMD9(0, 0, 0)  // Also used for panic() and guruMeditation().

--- a/source/arm11/hardware/codec.c
+++ b/source/arm11/hardware/codec.c
@@ -447,6 +447,22 @@ void CODEC_wakeup(void)
 	TIMER_sleepMs(18); // Fixed 18 ms delay when unsetting this GPIO.
 }
 
+void CODEC_muteI2S(void)
+{
+    codecMaskReg(0x00, 0x3F, 0x00, 0xC0);
+    codecWriteReg(0x00, 0x40, 0x0C);
+
+    codecMaskReg(0x64, 0x77, 0xC, 0xC);
+}
+
+void CODEC_unmuteI2S(void)
+{
+    codecMaskReg(0x00, 0x3F, 0xC0, 0xC0);
+    codecWriteReg(0x00, 0x40, 0x00);
+
+    codecMaskReg(0x64, 0x77, 0x0, 0xC);
+}
+
 bool CODEC_getRawAdcData(CdcAdcData *data)
 {
 	if((codecReadReg(0x67, 0x26) & 2u) == 0)

--- a/source/arm11/hardware/gfx.c
+++ b/source/arm11/hardware/gfx.c
@@ -365,7 +365,7 @@ void GFX_powerOnBacklights(GfxBlight mask)
 
 	mask <<= 1;
 	MCU_controlLCDPower(mask); // Power on backlights.
-	if(MCU_waitEvents(0x3Fu<<24) != (u32)mask<<24) panic();
+	//if(MCU_waitEvents(0x3Fu<<24) != (u32)mask<<24) panic();
 }
 
 void GFX_powerOffBacklights(GfxBlight mask)
@@ -374,7 +374,7 @@ void GFX_powerOffBacklights(GfxBlight mask)
 	g_gfxState.lcdPower &= ~mask;
 
 	MCU_controlLCDPower(mask); // Power off backlights.
-	if(MCU_waitEvents(0x3Fu<<24) != (u32)mask<<24) panic();
+	//if(MCU_waitEvents(0x3Fu<<24) != (u32)mask<<24) panic();
 }
 
 void GFX_setBrightness(u8 top, u8 bot)

--- a/source/arm9/arm7_stub.s
+++ b/source/arm9/arm7_stub.s
@@ -22,6 +22,28 @@
 .cpu arm7tdmi
 .fpu softvfp
 
+BEGIN_ASM_FUNC _a7_overlay_stub_capture
+	nop
+	nop
+
+_swi_v:
+    b .-8
+    b .
+    b .
+	b .
+
+    @ I tried to have it so interrupts would finish before forced sleeps,
+    @ but it made some games crash so on the off chance we're mid-interrupt,
+    @ consume a bit more power.
+	b . @ .+0x110
+
+_fiq_v:
+b .
+
+.pool
+.global _a7_overlay_stub_capture_size
+_a7_overlay_stub_capture_size = . - _a7_overlay_stub_capture
+END_ASM_FUNC
 
 
 BEGIN_ASM_FUNC _a7_overlay_stub

--- a/source/arm9/debug.c
+++ b/source/arm9/debug.c
@@ -22,12 +22,14 @@
 #include "mem_map.h"
 #include "hardware/pxi.h"
 #include "ipc_handler.h"
-//#include "fatfs/ff.h"
-//#include "fs.h"
+#include "fatfs/ff.h"
+#include "fs.h"
 #include "arm9/hardware/interrupt.h"
 #include "hardware/gfx.h"
 #include "arm9/hardware/ndma.h"
 
+
+u8 test_buf[0x2000];
 
 
 NOINLINE NOINLINE noreturn void panic(void)
@@ -74,7 +76,7 @@ NOINLINE noreturn void guruMeditation(UNUSED u8 type, UNUSED const u32 *excStack
 	}
 }
 
-/*void dumpMem(u8 *mem, u32 size, char *filepath)
+void dumpMem(u8 *mem, u32 size, char *filepath)
 {
 	FIL file;
 	UINT bytesWritten;
@@ -82,7 +84,13 @@ NOINLINE noreturn void guruMeditation(UNUSED u8 type, UNUSED const u32 *excStack
 	if(f_open(&file, filepath, FA_CREATE_ALWAYS | FA_WRITE) != FR_OK)
 		return;
 
-	f_write(&file, mem, size, &bytesWritten);
+	//f_write(&file, mem, size, &bytesWritten);
+	for (int i = 0; i < size; i += 0x1000)
+	{
+		NDMA_copy((u32*)&test_buf[0], (u32*)&mem[i], 0x1000);
+		f_write(&file, test_buf, 0x1000, &bytesWritten);
+	}
+
 	f_sync(&file);
 	f_close(&file);
-}*/
+}

--- a/source/arm9/ipc_handler.c
+++ b/source/arm9/ipc_handler.c
@@ -108,6 +108,14 @@ u32 IPC_handleCmd(u8 cmdId, u32 inBufs, u32 outBufs, const u32 *const buf)
 		case IPC_CMD_ID_MASK(IPC_CMD9_BACKUP_GBA_SAVE):
 			result = LGY_backupGbaSave();
 			break;
+	    case IPC_CMD_ID_MASK(IPC_CMD9_SLEEPGBA):
+			LGY_sleepGba();
+			result = 0;
+			break;
+	    case IPC_CMD_ID_MASK(IPC_CMD9_WAKEGBA):
+			LGY_wakeGba();
+			result = 0;
+			break;
 
 		// Miscellaneous API.
 		case IPC_CMD_ID_MASK(IPC_CMD9_PREPARE_POWER):


### PR DESCRIPTION
Not expecting this to be merged per-se but I figured it would be better to have the PR for discussion/experiments.

**Additions:**
- Basic sleep support
  - LCD backlight is turned off when lid is closed, and turned back on when it is opened.
  - Codec is muted when lid is closed and unmuted when lid is opened.
  - Backlight and codec are also adjusted when a GBA game suspends and a sleep IRQ is sent.
- Extended sleep support/Sleep-anywhere
  - When the lid is closed, `arm11` will signal to `arm9` to try and force the ARM7 into a suspended state.
  - Using the 0x20 byte bootrom overlay, ARM7 execution can be hijacked by trapping all vectors to infinite loop and waiting for a SWI call or IRQ. The ARM9 can then manipulate program flow within the overlay to set HALTCNT and suspend the ARM7 properly.
  - End result: GBA games are fully paused and suspended to low-power mode when the lid is closed.

**Current Regressions:**
- BIOS/logo boot is forced for now, due to the overlay being actively used for sleep-anywhere.
- Something is asserting on shutdown after the LCD backlight is turned off? Not sure if this affects saving or not.

**Other notes:**
- ARM7 hijacking might allow for savestates similar to how the EZ Flash Omega does them (dump all memory+registers to 0x0E000000, restore later). The only caveat iirc is that some IO is write-only.
- If the lid is closed during an IRQ, it will not suspend to low-power mode currently.
- The LCD and GPU are still active while sleeping.

If anyone wants to test the changes I have a build [here](https://github.com/shinyquagsire23/open_agb_firm/releases/tag/test-sleep-1).