### PR TITLE
Brightness Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ SELECT+Y - Dump screen output to `/3ds/open_agb_firm/texture_dump.bmp`
 * If the screen output freezes, press HOME to fix it. This is a hard to track down bug that will be fixed.
 
 X+UP/DOWN - Adjust screen brightness up or down by `backlightAdjustment` units
+X+LEFT - Turn off (both) screens
+X+RIGHT - Turn on (both) screens
 
 Hold the power button to turn off the 3DS.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A/B/L/R/START/SELECT - GBA buttons, respectively
 SELECT+Y - Dump screen output to `/3ds/open_agb_firm/texture_dump.bmp`
 * If the screen output freezes, press HOME to fix it. This is a hard to track down bug that will be fixed.
 
+X+UP/DOWN - Adjust screen brightness up or down by `backlightAdjustment` units
+
 Hold the power button to turn off the 3DS.
 
 ## Configuration
@@ -40,6 +42,9 @@ General settings.
   * Old 3DS: `20`-`117`
   * New 3DS: `16`-`142`
 * Values ≤`64` are recommended.
+
+`u8 backlightAdjustment` - How much to adjust backlight brightness by
+* Default: `5`
 
 `bool directBoot` - Skip GBA BIOS intro at game startup
 * Default: `false`
@@ -94,7 +99,7 @@ This section is reserved for a listing of known issues. At present only this rem
 * Sleep mode is not fully implemented.
 * Using SELECT+Y to dump screen output to a file can freeze the screen output sometimes.
 * Save type autodetection may still fail for certain games using EEPROM.
-* Lack of settings (including brightness control during gameplay).
+* Lack of settings.
 * No cheats and other enhancements.
 
 If you happen to stumble over another bug, please [open an issue](https://github.com/profi200/open_agb_firm/issues) or contact profi200 via other platforms.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ SELECT+Y - Dump screen output to `/3ds/open_agb_firm/texture_dump.bmp`
 * If the screen output freezes, press HOME to fix it. This is a hard to track down bug that will be fixed.
 
 X+UP/DOWN - Adjust screen brightness up or down by `backlightAdjustment` units
-X+LEFT - Turn off (both) screens
-X+RIGHT - Turn on (both) screens
+
+X+LEFT - Turn off display
+
+X+RIGHT - Turn on display
 
 Hold the power button to turn off the 3DS.
 

--- a/include/arm11/open_agb_firm.h
+++ b/include/arm11/open_agb_firm.h
@@ -24,6 +24,8 @@
 
 Result oafParseConfigEarly(void);
 u8 oafGetBacklightConfig(void);
+u8 oafGetBacklightAdjustmentConfig(void);
 Result oafInitAndRun(void);
 void oafUpdate(void);
 void oafFinish(void);
+void adjustBrightness(void);

--- a/source/arm11/main.c
+++ b/source/arm11/main.c
@@ -61,6 +61,8 @@ int main(void)
 	{
 		while(1)
 		{
+			adjustBrightness();
+
 			hidScanInput();
 			if(hidGetExtraKeys(0) & (KEY_POWER_HELD | KEY_POWER)) break;
 

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -564,6 +564,12 @@ static void gbaGfxHandler(void *args)
 		//adjust screen brightness down
 		if(hidKeysHeld() == (KEY_X | KEY_DDOWN) && hidKeysDown() != 0)
 			brightnessDown();
+		//turn off screen
+		if(hidKeysHeld() == (KEY_X | KEY_DLEFT) && hidKeysDown() != 0)
+			GFX_setBrightness(0, 0);
+		//turn on screen
+		if(hidKeysHeld() == (KEY_X | KEY_DRIGHT) && hidKeysDown() != 0)
+			GFX_setBrightness(currentBacklight, currentBacklight);
 	}
 
 	taskExit();


### PR DESCRIPTION
Added controls for adjusting display brightness in game.

Partially fulfills #58. It does not use the 3ds slider, but rather the X button along with UP/DOWN buttons to make it compatible with 2ds as well. Additionally, screen can be completely turned off with X+LEFT, and turned back on X+RIGHT. 

While this implementation is limited (screen brightness is reset to ini value after reset) and a bit clunky (game still registers d-pad presses, and controls are not necessarily intuitive), it does allow for users to change brightness without restarting the console