### PR TITLE
Add mgba save compatibility option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ Options for advanced users. No pun intended.
   * `11`, `13`: Flash 1m
   * `14`: SRAM 256k
   * `15`: None
+  
+`bool mgbaSaveCompat` - Look for and place romName.sav and romName.ini in the ROM directory for compatibility with mbga save behavior.
+* Default: `false`
 
 ## Patches
 open_agb_firm supports automatically applying IPS and UPS patches. To use a patch, rename the patch file to match the ROM file name (without the extension).

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Options for advanced users. No pun intended.
   * `14`: SRAM 256k
   * `15`: None
   
-`bool mgbaSaveCompat` - Look for and place romName.sav and romName.ini in the ROM directory for compatibility with mbga save behavior.
+`bool mgbaSaveCompat` - Look for and place romName.sav and romName.ini in the ROM directory for compatibility with mGBA save behavior.
 * Default: `false`
 
 ## Patches

--- a/include/arm11/config.h
+++ b/include/arm11/config.h
@@ -52,6 +52,7 @@ typedef struct
 	// [advanced]
 	bool saveOverride;
 	u16 defaultSave;
+	bool mgbaSaveCompat;
 } OafConfig;
 //static_assert(sizeof(OafConfig) == 76, "nope");
 

--- a/source/arm11/config.c
+++ b/source/arm11/config.c
@@ -43,7 +43,8 @@
                         "volume=127\n\n"          \
                         "[advanced]\n"            \
                         "saveOverride=false\n"    \
-                        "defaultSave=14"
+                        "defaultSave=14\n"        \
+						"mgbaSaveCompat=false"
 
 
 
@@ -142,6 +143,8 @@ static int cfgIniCallback(void* user, const char* section, const char* name, con
 			config->saveOverride = (strcmp(value, "false") == 0 ? false : true);
 		if(strcmp(name, "defaultSave") == 0)
 			config->defaultSave = (u16)strtoul(value, NULL, 10);
+		if(strcmp(name, "mgbaSaveCompat") == 0)
+			config->mgbaSaveCompat = (strcmp(value, "false") == 0 ? false : true);
 	}
 	else return 0; // Error.
 

--- a/source/arm11/config.c
+++ b/source/arm11/config.c
@@ -44,7 +44,7 @@
                         "[advanced]\n"            \
                         "saveOverride=false\n"    \
                         "defaultSave=14\n"        \
-						"mgbaSaveCompat=false"
+                        "mgbaSaveCompat=false"
 
 
 


### PR DESCRIPTION
Supersedes #177 
This adds an advanced option (mgbaSaveCompat) to swap save and ROM .ini files to be in the same directory as the ROM. This allows a user to play on mGBA and seamlessly swap over to open_agb without moving saves around.

Neither mGBA nor open_agb allowed configuring save locations, so this would provide the only option for users wanting to be able to swap between them easily.