### PR TITLE
Toggle power LED on START+Y

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ SELECT+Y - Dump hardware frame output to `/3ds/open_agb_firm/screenshots/YYYY_MM
 * The file name is the current date and time from your real-time clock.
 * If the screen output freezes, press HOME to fix it. This is a hard to track down bug that will be fixed.
 
-Y+DOWN - Turn off the power LED
+START+Y - Toggle power LED on/off.
 
 X+UP/DOWN - Adjust screen brightness up or down by `backlightSteps` units.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ SELECT+Y - Dump hardware frame output to `/3ds/open_agb_firm/screenshots/YYYY_MM
 * The file name is the current date and time from your real-time clock.
 * If the screen output freezes, press HOME to fix it. This is a hard to track down bug that will be fixed.
 
+Y+DOWN - Turn off the power LED
+
 X+UP/DOWN - Adjust screen brightness up or down by `backlightSteps` units.
 
 X+LEFT - Turn off LCD backlight.

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -122,6 +122,11 @@ void changeBacklight(s16 amount)
 	GFX_setLcdLuminance(newVal);
 }
 
+void turnOffPowerLED()
+{
+	MCU_setPowerLedPattern(MCU_PWR_LED_OFF);
+}
+
 static void updateBacklight(void)
 {
 	// Check for special button combos.
@@ -129,6 +134,10 @@ static void updateBacklight(void)
 	static bool backlightOn = true;
 	if(hidKeysDown() && kHeld)
 	{
+		// Turn off power LED
+		if (kHeld == (KEY_Y | KEY_DDOWN))
+			turnOffPowerLED();
+
 		// Adjust LCD brightness up.
 		const s16 steps = g_oafConfig.backlightSteps;
 		if(kHeld == (KEY_X | KEY_DUP))

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -41,7 +41,7 @@
 
 
 static KHandle g_frameReadyEvent = 0;
-
+static PwrLedPattern g_lastPowerLEDPattern = MCU_PWR_LED_AUTO;
 
 
 static u32 fixRomPadding(const u32 romFileSize)
@@ -122,9 +122,19 @@ void changeBacklight(s16 amount)
 	GFX_setLcdLuminance(newVal);
 }
 
-void turnOffPowerLED()
+void togglePowerLED()
 {
-	MCU_setPowerLedPattern(MCU_PWR_LED_OFF);
+	PwrLedPattern currentPattern = MCU_getPowerLedPattern();
+	if (currentPattern == MCU_PWR_LED_OFF)
+	{
+		// Restore last know pattern.
+		MCU_setPowerLedPattern(g_lastPowerLEDPattern);
+	}
+	else
+	{
+		MCU_setPowerLedPattern(MCU_PWR_LED_OFF);
+	}
+	g_lastPowerLEDPattern = currentPattern;
 }
 
 static void updateBacklight(void)
@@ -134,9 +144,9 @@ static void updateBacklight(void)
 	static bool backlightOn = true;
 	if(hidKeysDown() && kHeld)
 	{
-		// Turn off power LED
-		if (kHeld == (KEY_Y | KEY_DDOWN))
-			turnOffPowerLED();
+		// Toggle power LED.
+		if (kHeld == (KEY_Y | KEY_START))
+			togglePowerLED();
 
 		// Adjust LCD brightness up.
 		const s16 steps = g_oafConfig.backlightSteps;


### PR DESCRIPTION
The blue power LED is annoying when playing in the dark.
Map a new input combo (Y+DOWN) to turn it off.