### PR TITLE
Added remap support for hotkeys (backlight brightness, screenshot, etc) and ability to disable certain hotkeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /tools/gba-db/gba.*
 !/tools/gba-db/gba.csv
 /open_agb_firm*.*
+/ctr_firm_builder-master

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ General settings.
 `bool useSavesFolder` - Use `/3ds/open_agb_firm/saves` for save files instead of the ROM directory.
 * Default: `true`
 
+`bool enableBacklightHotkeys` - Enables/disables the backlight adjustment hotkeys.
+* Default: `true`
+
+`bool enableScreenshotHotkey` - Enables/disables the hardware frame dump hotkey.
+* Default: `true`
+
 ### Video
 Video-related settings.
 
@@ -155,6 +161,38 @@ RIGHT=RIGHT,CP_RIGHT
 LEFT=LEFT,CP_LEFT
 UP=UP,CP_UP
 DOWN=DOWN,CP_DOWN
+```
+
+### Hotkeys
+Hotkey input settings. These use the same formatting as regular inputs. Entries with multiple buttons are treated as button combos (all buttons must be pressed), unlike regular inputs.
+
+`takeScreenshot` - Button map for dumping hardware frame output.
+* Default: `SELECT,Y`
+
+`backlightUp` - Button map for increasing screen brightness.
+* Default: `X,UP`
+
+`backlightDown` - Button map for decreasing screen brightness.
+* Default: `X,DOWN`
+
+`backlightOff` - Button map for turning off LCD backlight.
+* Default: `X,LEFT`
+
+`backlightOn` - Button map for turning on LCD backlight.
+* Default: `X,RIGHT`
+
+`skipPatching` - Button map for skipping patching upon game launch.
+* Default: `X`
+
+Notes: The general setting `enableBacklightHotkeys` must be set to `true` to use the backlight hotkeys. `enableScreenshotHotkey` must be `true` to dump hardware frames.
+
+Example which maps Y + D-Pad to backlight controls:
+```
+[hotkeys]
+backlightUp=Y,UP
+backlightDown=Y,DOWN
+backlightOff=Y,LEFT
+backlightOn=Y,RIGHT
 ```
 
 ### Game

--- a/include/arm11/config.h
+++ b/include/arm11/config.h
@@ -58,6 +58,14 @@ typedef struct
 	// [input]
 	u32 buttonMaps[10]; // A, B, Select, Start, Right, Left, Up, Down, R, L.
 
+	// [hotkeys]
+	u32 takeScreenshot;
+	u32 backlightUp;
+	u32 backlightDown;
+	u32 backlightOff;
+	u32 backlightOn;
+	u32 skipPatching;
+
 	// [game]
 	u8 saveSlot;
 	u8 saveType;

--- a/include/arm11/config.h
+++ b/include/arm11/config.h
@@ -40,6 +40,8 @@ typedef struct
 	bool directBoot;
 	bool useGbaDb;
 	bool useSavesFolder;
+	bool enableBacklightHotkeys;
+	bool enableScreenshotHotkey;
 
 	// [video]
 	u8 scaler;          // 0 = 1:1/none, 1 = bilinear (GPU) x1.5, 2 = matrix (hardware) x1.5.

--- a/source/arm11/config.c
+++ b/source/arm11/config.c
@@ -89,6 +89,14 @@ OafConfig g_oafConfig =
 		0  // L
 	},
 
+	// [hotkeys]
+	2052,     // takeScreenshot (SELECT+Y, hex: 805)
+	1088,     // backlightUp (X+UP, hex: 440)
+	1152,     // backlightDown (X+DOWN, hex: 480)
+	1056,     // backlightOff (X+LEFT, hex: 420)
+	1040,     // backlightOn (X+RIGHT, hex: 410)
+	1024,     // skipPatching (X, hex: 400)
+
 	// [game]
 	0,     // saveSlot
 	255,   // saveType
@@ -221,6 +229,29 @@ static int cfgIniCallback(void *user, const char *section, const char *name, con
 			const u32 shift = 31u - __builtin_clzl(button);
 			const u32 map   = parseButtons(value);
 			config->buttonMaps[shift] = map;
+		}
+	}
+	else if(strcmp(section, "hotkeys") == 0)
+	{
+		// get the button (combo) set for this hotkey
+		const u32 map = parseButtons(value);
+
+		// if map isn't zero...
+		if (map != 0)
+		{
+			// set the mapping to its corrisponding variable based on name
+			if(strcmp(name, "takeScreenshot") == 0)
+				config->takeScreenshot = map;
+			else if(strcmp(name, "backlightUp") == 0)
+				config->backlightUp = map;
+			else if(strcmp(name, "backlightDown") == 0)
+				config->backlightDown = map;
+			else if(strcmp(name, "backlightOff") == 0)
+				config->backlightOff = map;
+			else if(strcmp(name, "backlightOn") == 0)
+				config->backlightOn = map;
+			else if(strcmp(name, "skipPatching") == 0)
+				config->skipPatching = map;
 		}
 	}
 	else if(strcmp(section, "game") == 0)

--- a/source/arm11/config.c
+++ b/source/arm11/config.c
@@ -26,26 +26,28 @@
 
 
 #define INI_BUF_SIZE    (1024u)
-#define DEFAULT_CONFIG  "[general]\n"             \
-                        "backlight=64\n"          \
-                        "backlightSteps=5\n"      \
-                        "directBoot=false\n"      \
-                        "useGbaDb=true\n"         \
-                        "useSavesFolder=true\n\n" \
-                                                  \
-                        "[video]\n"               \
-                        "scaler=matrix\n"         \
-                        "colorProfile=none\n"     \
-                        "contrast=1.0\n"          \
-                        "brightness=0.0\n"        \
-                        "saturation=1.0\n\n"      \
-                                                  \
-                        "[audio]\n"               \
-                        "audioOut=auto\n"         \
-                        "volume=127\n\n"          \
-                                                  \
-                        "[advanced]\n"            \
-                        "saveOverride=false\n"    \
+#define DEFAULT_CONFIG  "[general]\n"                       \
+                        "backlight=64\n"                    \
+                        "backlightSteps=5\n"                \
+                        "directBoot=false\n"                \
+                        "useGbaDb=true\n"                   \
+                        "useSavesFolder=true\n"             \
+                        "enableBacklightHotkeys=true\n"     \
+                        "enableScreenshotHotkey=true\n\n"   \
+                                                            \
+                        "[video]\n"                         \
+                        "scaler=matrix\n"                   \
+                        "colorProfile=none\n"               \
+                        "contrast=1.0\n"                    \
+                        "brightness=0.0\n"                  \
+                        "saturation=1.0\n\n"                \
+                                                            \
+                        "[audio]\n"                         \
+                        "audioOut=auto\n"                   \
+                        "volume=127\n\n"                    \
+                                                            \
+                        "[advanced]\n"                      \
+                        "saveOverride=false\n"              \
                         "defaultSave=sram_256k"
 
 
@@ -59,6 +61,8 @@ OafConfig g_oafConfig =
 	false, // directBoot
 	true,  // useGbaDb
 	true,  // useSavesFolder
+	true,  // enableBacklightHotkeys
+	true,  // enableScreenshotHotkey
 
 	// [video]
 	2,     // scaler
@@ -148,6 +152,10 @@ static int cfgIniCallback(void *user, const char *section, const char *name, con
 			config->useGbaDb = (strcmp(value, "true") == 0 ? true : false);
 		else if(strcmp(name, "useSavesFolder") == 0)
 			config->useSavesFolder = (strcmp(value, "true") == 0 ? true : false);
+		else if(strcmp(name, "enableBacklightHotkeys") == 0)
+			config->enableBacklightHotkeys = (strcmp(value, "true") == 0 ? true : false);
+		else if(strcmp(name, "enableScreenshotHotkey") == 0)
+			config->enableScreenshotHotkey = (strcmp(value, "true") == 0 ? true : false);
 	}
 	else if(strcmp(section, "video") == 0)
 	{

--- a/source/arm11/oaf_video.c
+++ b/source/arm11/oaf_video.c
@@ -391,8 +391,8 @@ static void gbaGfxHandler(void *args)
 		GFX_waitForPPF();
 		GFX_swapBuffers();
 
-		// Trigger only if both are held and at least one is detected as newly pressed down.
-		if(hidKeysHeld() == (KEY_Y | KEY_SELECT) && hidKeysDown() != 0)
+		// Trigger only if enableScreenshotHotkey setting is true, and both keys are held and at least one is detected as newly pressed down.
+		if (g_oafConfig.enableScreenshotHotkey && hidKeysHeld() == (KEY_Y | KEY_SELECT) && hidKeysDown() != 0)
 			dumpFrameTex();
 	}
 

--- a/source/arm11/oaf_video.c
+++ b/source/arm11/oaf_video.c
@@ -391,8 +391,8 @@ static void gbaGfxHandler(void *args)
 		GFX_waitForPPF();
 		GFX_swapBuffers();
 
-		// Trigger only if enableScreenshotHotkey setting is true, and both keys are held and at least one is detected as newly pressed down.
-		if (g_oafConfig.enableScreenshotHotkey && hidKeysHeld() == (KEY_Y | KEY_SELECT) && hidKeysDown() != 0)
+		// Trigger only if enableScreenshotHotkey setting is true, and key(s) are held and at least one is detected as newly pressed down.
+		if (g_oafConfig.enableScreenshotHotkey && hidKeysHeld() == g_oafConfig.takeScreenshot && hidKeysDown() != 0)
 			dumpFrameTex();
 	}
 

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -131,11 +131,11 @@ static void updateBacklight(void)
 	{
 		// Adjust LCD brightness up.
 		const s16 steps = g_oafConfig.backlightSteps;
-		if(kHeld == (KEY_X | KEY_DUP))
+		if(kHeld == g_oafConfig.backlightUp)
 			changeBacklight(steps);
 
 		// Adjust LCD brightness down.
-		if(kHeld == (KEY_X | KEY_DDOWN))
+		if(kHeld == g_oafConfig.backlightDown)
 			changeBacklight(-steps);
 
 		// Disable backlight switching in debug builds on 2DS.
@@ -145,14 +145,14 @@ static void updateBacklight(void)
 #endif
 		{
 			// Turn off backlight.
-			if(backlightOn && kHeld == (KEY_X | KEY_DLEFT))
+			if(backlightOn && kHeld == g_oafConfig.backlightOff)
 			{
 				backlightOn = false;
 				GFX_powerOffBacklight(lcd);
 			}
 
 			// Turn on backlight.
-			if(!backlightOn && kHeld == (KEY_X | KEY_DRIGHT))
+			if(!backlightOn && kHeld == g_oafConfig.backlightOn)
 			{
 				backlightOn = true;
 				GFX_powerOnBacklight(lcd);

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -364,7 +364,8 @@ void oafUpdate(void)
 	LGY11_setInputState(pressed);
 
 	CODEC_runHeadphoneDetection();
-	updateBacklight();
+	if (g_oafConfig.enableBacklightHotkeys)
+		updateBacklight();
 	waitForEvent(g_frameReadyEvent);
 	clearEvent(g_frameReadyEvent);
 }

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -22,6 +22,7 @@
 #include "oaf_error_codes.h"
 #include "util.h"
 #include "arm11/drivers/hid.h"
+#include "arm11/config.h"
 #include "drivers/lgy_common.h"
 #include "arm11/fmt.h"
 #include "fs.h"
@@ -240,7 +241,7 @@ Result patchRom(const char *const gamePath, u32 *romSize) {
 
 	//if X is held during launch, skip patching
 	hidScanInput();
-	if(hidKeysHeld() == KEY_X)
+	if(hidKeysHeld() == g_oafConfig.skipPatching)
 		return res;
 
 	//get base path for game with 'gba' extension removed


### PR DESCRIPTION
I tried remapping X to B on my 3DS and realised it conflicted with the hotkeys for controlling the backlight, so I decided to make a fix by adding an option to enable/disable the backlight hotkeys, along with the screenshot hotkey for consistency.

I then added the ability to remap each existing hotkey to a different button combo, since I noticed some people were wanting it (#202 and #172) and seemed like a better solution to the initial problem. I've still kept the option for disabling the hotkeys though, since it could still be useful for who wouldn't want to adjust the backlight in-game or take screenshots.

This is the first time I've done a pull request for an open source project, so apologies if there's something I haven't done correctly. I've compiled and tested my changes on real hardware (original 3DS XL) and all seems to be good, and I've updated the readme to reflect my changes. 