### PR TITLE
Refactor UPS patching

### DIFF
--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -39,19 +39,19 @@
 typedef struct
 {
 	u8 *buffer;
-	u16 cacheSize;
-	u16 cacheOffset;
-	u16 maxCacheSize;
+	u16 size;
+	u16 offset;
+	u16 capacity;
 } Cache;
 
 
 
 static u8 readCache(const FHandle patchHandle, Cache *cache, Result *res) {
-	u8 result = (cache->buffer)[(cache->cacheOffset)++];
-	if((cache->cacheOffset) >= (cache->cacheSize)) {
-		(cache->cacheSize) = min((cache->maxCacheSize), ((fSize(patchHandle)-12) - fTell(patchHandle)));
-		*res = fRead(patchHandle, (cache->buffer), (cache->cacheSize), NULL);
-		(cache->cacheOffset) = 0;
+	u8 result = (cache->buffer)[(cache->offset)++];
+	if((cache->offset) >= (cache->capacity)) {
+		(cache->size) = min((cache->capacity), ((fSize(patchHandle)-12) - fTell(patchHandle)));
+		*res = fRead(patchHandle, (cache->buffer), (cache->size), NULL);
+		(cache->offset) = 0;
 	}
 
 	return result;
@@ -150,10 +150,10 @@ static uintmax_t read_vuint(const FHandle patchFile, Result *res, Cache *cache) 
 
 static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	Cache cache = {
-		(u8*)calloc(512, 1), //buffer
-		0,                   //cache size
-		0,                   //cache offset
-		512                  //max cache size
+		(u8*)calloc(512, 1), // Buffer.
+		0,                   // Size.
+		0,                   // Offset.
+		512                  // Capacity.
 	};
 	if(cache.buffer == NULL) return RES_OUT_OF_MEM;
 
@@ -168,8 +168,8 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	patchSize -= UPS_CRC_SIZE;
 
 	// Try to perform initial caching.
-	cache.cacheSize = min(cache.maxCacheSize, patchSize);
-	Result res = fRead(patchHandle, cache.buffer, cache.cacheSize, NULL);
+	cache.size = min(cache.capacity, patchSize);
+	Result res = fRead(patchHandle, cache.buffer, cache.size, NULL);
 	if(res != RES_OK)
 	{
 		free(cache.buffer);
@@ -184,7 +184,7 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 		free(cache.buffer);
 		return RES_INVALID_PATCH;
 	}
-	cache.cacheOffset += UPS_MAGIC_SIZE;
+	cache.offset += UPS_MAGIC_SIZE;
 
 	// Get unpatched and patched ROM sizes.
 	u32 baseRomSize = (u32)read_vuint(patchHandle, &res, &cache);

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -144,12 +144,12 @@ static Result patchIPS(const FHandle patchHandle) {
 }
 
 //based on code from http://fileformats.archiveteam.org/wiki/UPS_(binary_patch_format) (CC0, No copyright)
-static uintmax_t read_vuint(const UPSPatch *patch, Result *res, Cache *cache) {
-	uintmax_t result = 0, shift = 0;
+static u32 read_vuint(const UPSPatch *patch, Result *res, Cache *cache)
+{
+	u32 result = 0, shift = 0;
 
-	uint8_t octet = 0;
+	u8 octet = 0;
 	for (;;) {
-		//*res = fRead(patchFile, &octet, 1, NULL);
 		octet = readCache(patch, cache, res);
 		if(*res != RES_OK) break;
 		if(octet & 0x80) {
@@ -172,10 +172,10 @@ static Result loadUPSMetadata(UPSPatch *patch, Cache *cache)
 
 	// Decode base and patched ROM sizes.
 	Result res = RES_OK;
-	patch->baseRomSize = (u32)read_vuint(patch, &res, cache);
+	patch->baseRomSize = read_vuint(patch, &res, cache);
 	if(res != RES_OK) return res;
 
-	patch->patchedRomSize = (u32)read_vuint(patch, &res, cache);
+	patch->patchedRomSize = read_vuint(patch, &res, cache);
 	if(res != RES_OK) return res;
 
 	debug_printf("Base size:    0x%lx\nPatched size: 0x%lx\n", patch->baseRomSize, patch->patchedRomSize);

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -22,6 +22,9 @@
 #include "oaf_error_codes.h"
 #include "util.h"
 #include "arm11/drivers/hid.h"
+#ifndef NDEBUG
+#include "arm11/drivers/mcu.h"
+#endif
 #include "drivers/lgy_common.h"
 #include "arm11/fmt.h"
 #include "fs.h"
@@ -52,6 +55,21 @@ typedef struct
 } UPSPatch;
 
 
+
+#ifndef NDEBUG
+static u8 elapsedSecs(const RtcTimeDate *before, const RtcTimeDate *after)
+{
+	// RtcTimeDate seconds are represented as hex, i.e. the 59th second is 0x59.
+	// Convert those to decimal so we can do decent math on them.
+	u8 beforeSecs = (before->sec / 16 * 10) + (before->sec % 16);
+	u8 afterSecs = (after->sec / 16 * 10) + (after->sec % 16);
+
+	// NOTE: only accounts for the first minute boundary.
+	if(afterSecs < beforeSecs) afterSecs += 60;
+
+	return afterSecs - beforeSecs;
+}
+#endif
 
 static u8 readCache(const UPSPatch *patch, Cache *cache, Result *res)
 {
@@ -308,7 +326,15 @@ Result patchRom(const char *const gamePath, u32 *romSize) {
 
 		if ((res = fOpen(&f, strcat(patchPathBase, "ups"), FA_OPEN_EXISTING | FA_READ)) == RES_OK) 
 		{
+#ifndef NDEBUG
+			RtcTimeDate before, after;
+			MCU_getRtcTimeDate(&before);
+#endif
 			res = patchUPS(f, romSize);
+#ifndef NDEBUG
+			MCU_getRtcTimeDate(&after);
+			debug_printf("Patching took: %us\n", elapsedSecs(&before, &after));
+#endif
 
 			if(res != RES_OK && res != RES_INVALID_PATCH) {
 				ee_puts("An error has occurred while patching.\nContinuing is NOT recommended!\n\nPress Y+UP to proceed");

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -165,69 +165,66 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 
 	ee_puts("UPS patch found! Patching...");
 
-	//verify patch is UPS (magic number is "UPS1")
-	u8 magic[] = {0x00, 0x00, 0x00, 0x00}; 
-	bool isValidPatch = false;
-	for(u8 i=0; i<4; i++) {
-		magic[i] = readCache(patchHandle, &cache, &res);
+	// Verify the patch is indeed UPS.
+	u8 magic[] = {'U', 'P', 'S', '1'};
+	for(u8 i = 0; i < sizeof(magic) / sizeof(magic[0]); i++) {
+		u8 c = readCache(patchHandle, &cache, &res);
 		if(res != RES_OK) break;
-	}
-
-	if(res == RES_OK) {
-		if(memcmp(&magic, "UPS1", 4) == 0) {
-			isValidPatch = true;
-		} else {
+		if(c != magic[i]) {
 			res = RES_INVALID_PATCH;
+			break;
 		}
 	}
+	if(res != RES_OK) {
+		free(cache.buffer);
+		return res;
+	}
 
-	if(isValidPatch) {
-		//get rom size
-		u32 baseRomSize = (u32)read_vuint(patchHandle, &res, &cache);
-		if(res != RES_OK) { free(cache.buffer); return res; }
-		//get patched rom size
-		u32 patchedRomSize = (u32)read_vuint(patchHandle, &res, &cache);
-		if(res != RES_OK) { free(cache.buffer); return res; }
+	//get rom size
+	u32 baseRomSize = (u32)read_vuint(patchHandle, &res, &cache);
+	if(res != RES_OK) { free(cache.buffer); return res; }
+	//get patched rom size
+	u32 patchedRomSize = (u32)read_vuint(patchHandle, &res, &cache);
+	if(res != RES_OK) { free(cache.buffer); return res; }
 
-		debug_printf("Base size:    0x%lx\nPatched size: 0x%lx\n", baseRomSize, patchedRomSize);
+	debug_printf("Base size:    0x%lx\nPatched size: 0x%lx\n", baseRomSize, patchedRomSize);
 
-		// Patched ROMs greater than 32MiB are always invalid.
-		if(patchedRomSize > LGY_MAX_ROM_SIZE) {
-			ee_puts("Patched ROM exceeds 32MiB! Skipping patching...");
-			free(cache.buffer);
-			return RES_INVALID_PATCH;
-		}
+	// Patched ROMs greater than 32MiB are always invalid.
+	// Patches are always valid past this check.
+	if(patchedRomSize > LGY_MAX_ROM_SIZE) {
+		ee_puts("Patched ROM exceeds 32MiB! Skipping patching...");
+		free(cache.buffer);
+		return RES_INVALID_PATCH;
+	}
 
-		// Scale up ROM if needed.
-		if(patchedRomSize > baseRomSize) {
-			*romSize = nextPow2(patchedRomSize);
-			memset((char*)(LGY_ROM_LOC + baseRomSize), 0xFFu, *romSize - baseRomSize); //fill out extra rom space
-			memset((char*)(LGY_ROM_LOC + baseRomSize), 0x00u, patchedRomSize - baseRomSize); //fill new patch area with 0's
-		}
+	// Scale up ROM if needed.
+	if(patchedRomSize > baseRomSize) {
+		*romSize = nextPow2(patchedRomSize);
+		memset((char*)(LGY_ROM_LOC + baseRomSize), 0xFFu, *romSize - baseRomSize); //fill out extra rom space
+		memset((char*)(LGY_ROM_LOC + baseRomSize), 0x00u, patchedRomSize - baseRomSize); //fill new patch area with 0's
+	}
 
-		uintmax_t patchFileSize = fSize(patchHandle);
+	uintmax_t patchFileSize = fSize(patchHandle);
 
-		uintmax_t offset = 0;
-		u8 readByte = 0;
-		u8 *romBytes = ((u8*)LGY_ROM_LOC);
+	uintmax_t offset = 0;
+	u8 readByte = 0;
+	u8 *romBytes = ((u8*)LGY_ROM_LOC);
 
-		while(fTell(patchHandle) < (patchFileSize-12) && res==RES_OK) {
-			offset += read_vuint(patchHandle, &res, &cache);
+	while(fTell(patchHandle) < (patchFileSize-12) && res==RES_OK) {
+		offset += read_vuint(patchHandle, &res, &cache);
+		if(res != RES_OK) break;
+
+		while(offset<*romSize) {
+			readByte = readCache(patchHandle, &cache, &res);
 			if(res != RES_OK) break;
 
-			while(offset<*romSize) {
-				readByte = readCache(patchHandle, &cache, &res);
-				if(res != RES_OK) break;
-
-				if(readByte == 0x00) {
-					offset++;
-					break; 
-				}
-				romBytes[offset] ^= readByte;
+			if(readByte == 0x00) {
 				offset++;
+				break;
 			}
+			romBytes[offset] ^= readByte;
+			offset++;
 		}
-
 	}
 
 	free(cache.buffer);

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -67,6 +67,11 @@ static u8 readCache(const UPSPatch *patch, Cache *cache, Result *res)
 	return byte;
 }
 
+static bool hasDataLeft(const Cache *cache)
+{
+	return cache->offset < cache->size;
+}
+
 static Result patchIPS(const FHandle patchHandle) {
 	ee_puts("IPS patch found! Patching...");
 
@@ -240,7 +245,7 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	// Patch the ROM.
 	u32 offset = 0;
 	u8 *romBytes = ((u8*)LGY_ROM_LOC);
-	while(fTell(patch.handle) < patch.size && res == RES_OK)
+	while(hasDataLeft(&cache) && res == RES_OK)
 	{
 		offset += read_vuint(&patch, &res, &cache);
 		if(res != RES_OK) break;

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -35,7 +35,7 @@
 
 #define min(a, b)  ((size_t) (a) <= (size_t) (b) ? (size_t) (a) : (size_t) (b))
 
-#define BUFFER_CAPACITY  512
+#define BUFFER_CAPACITY  4096
 #define UPS_MAGIC_SIZE   4
 #define UPS_CRC_SIZE     4 * 3
 

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -191,22 +191,12 @@ static Result loadUPSMetadata(UPSPatch *patch, Cache *cache)
 }
 
 static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
-	Cache cache = {
-		(u8*)calloc(512, 1), // Buffer.
-		0,                   // Size.
-		0,                   // Offset.
-		512                  // Capacity.
-	};
-	if(cache.buffer == NULL) return RES_OUT_OF_MEM;
+	ee_puts("UPS patch found! Patching...");
 
 	// Reject patches shorter than header + CRC hashes.
 	// Compute length minus hashes when done.
 	u32 patchSize = fSize(patchHandle);
-	if(patchSize < UPS_MAGIC_SIZE + UPS_CRC_SIZE)
-	{
-		free(cache.buffer);
-		return RES_INVALID_PATCH;
-	}
+	if(patchSize < UPS_MAGIC_SIZE + UPS_CRC_SIZE) return RES_INVALID_PATCH;
 	patchSize -= UPS_CRC_SIZE;
 
 	UPSPatch patch = {
@@ -217,15 +207,20 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	};
 
 	// Try to perform initial caching.
-	cache.size = min(cache.capacity, patch.size);
+	Cache cache = {
+		(u8*)calloc(512, 1),  // Buffer.
+		min(512, patch.size), // Size.
+		0,                    // Offset.
+		512                   // Capacity.
+	};
+	if(cache.buffer == NULL) return RES_OUT_OF_MEM;
+
 	Result res = fRead(patch.handle, cache.buffer, cache.size, NULL);
 	if(res != RES_OK)
 	{
 		free(cache.buffer);
 		return res;
 	}
-
-	ee_puts("UPS patch found! Patching...");
 
 	// Validate the patch and load the metadata.
 	if((res = loadUPSMetadata(&patch, &cache)) != RES_OK)

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -32,6 +32,9 @@
 
 #define min(a, b)  ((size_t) (a) <= (size_t) (b) ? (size_t) (a) : (size_t) (b))
 
+#define UPS_MAGIC_SIZE 4
+#define UPS_CRC_SIZE 4 * 3
+
 
 typedef struct
 {
@@ -158,8 +161,17 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 		return RES_OUT_OF_MEM;
 	}
 
+	// Reject patches shorter than header + CRC hashes.
+	// Compute length minus hashes when done.
+	u32 patchSize = fSize(patchHandle);
+	if(patchSize < UPS_MAGIC_SIZE + UPS_CRC_SIZE) {
+		free(cache.buffer);
+		return RES_INVALID_PATCH;
+	}
+	patchSize -= UPS_CRC_SIZE;
+
 	//read data into cache for first time
-	cache.cacheSize = min(cache.maxCacheSize, (fSize(patchHandle)-12)-fTell(patchHandle));
+	cache.cacheSize = min(cache.maxCacheSize, patchSize);
 	res = fRead(patchHandle, cache.buffer, cache.cacheSize, NULL);
 	if(res != RES_OK) { free(cache.buffer); return res; }
 
@@ -204,13 +216,11 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 		memset((char*)(LGY_ROM_LOC + baseRomSize), 0x00u, patchedRomSize - baseRomSize); //fill new patch area with 0's
 	}
 
-	uintmax_t patchFileSize = fSize(patchHandle);
-
-	uintmax_t offset = 0;
+	u32 offset = 0;
 	u8 readByte = 0;
 	u8 *romBytes = ((u8*)LGY_ROM_LOC);
 
-	while(fTell(patchHandle) < (patchFileSize-12) && res==RES_OK) {
+	while(fTell(patchHandle) < patchSize && res == RES_OK) {
 		offset += read_vuint(patchHandle, &res, &cache);
 		if(res != RES_OK) break;
 

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -53,15 +53,18 @@ typedef struct
 
 
 
-static u8 readCache(const FHandle patchHandle, Cache *cache, Result *res) {
-	u8 result = (cache->buffer)[(cache->offset)++];
-	if((cache->offset) >= (cache->capacity)) {
-		(cache->size) = min((cache->capacity), ((fSize(patchHandle)-12) - fTell(patchHandle)));
-		*res = fRead(patchHandle, (cache->buffer), (cache->size), NULL);
-		(cache->offset) = 0;
+static u8 readCache(const UPSPatch *patch, Cache *cache, Result *res)
+{
+	u8 byte = cache->buffer[cache->offset++];
+
+	// Load new block of data from patch if needed.
+	if(cache->offset >= cache->capacity) {
+		cache->size = min(cache->capacity, patch->size - fTell(patch->handle));
+		*res = fRead(patch->handle, cache->buffer, cache->size, NULL);
+		cache->offset = 0;
 	}
 
-	return result;
+	return byte;
 }
 
 static Result patchIPS(const FHandle patchHandle) {
@@ -136,13 +139,13 @@ static Result patchIPS(const FHandle patchHandle) {
 }
 
 //based on code from http://fileformats.archiveteam.org/wiki/UPS_(binary_patch_format) (CC0, No copyright)
-static uintmax_t read_vuint(const FHandle patchFile, Result *res, Cache *cache) {
+static uintmax_t read_vuint(const UPSPatch *patch, Result *res, Cache *cache) {
 	uintmax_t result = 0, shift = 0;
 
 	uint8_t octet = 0;
 	for (;;) {
 		//*res = fRead(patchFile, &octet, 1, NULL);
-		octet = readCache(patchFile, cache, res);
+		octet = readCache(patch, cache, res);
 		if(*res != RES_OK) break;
 		if(octet & 0x80) {
 			result += (octet & 0x7f) << shift;
@@ -164,10 +167,10 @@ static Result loadUPSMetadata(UPSPatch *patch, Cache *cache)
 
 	// Decode base and patched ROM sizes.
 	Result res = RES_OK;
-	patch->baseRomSize = (u32)read_vuint(patch->handle, &res, cache);
+	patch->baseRomSize = (u32)read_vuint(patch, &res, cache);
 	if(res != RES_OK) return res;
 
-	patch->patchedRomSize = (u32)read_vuint(patch->handle, &res, cache);
+	patch->patchedRomSize = (u32)read_vuint(patch, &res, cache);
 	if(res != RES_OK) return res;
 
 	debug_printf("Base size:    0x%lx\nPatched size: 0x%lx\n", patch->baseRomSize, patch->patchedRomSize);
@@ -240,12 +243,12 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 
 	while(fTell(patch.handle) < patch.size && res == RES_OK)
 	{
-		offset += read_vuint(patch.handle, &res, &cache);
+		offset += read_vuint(&patch, &res, &cache);
 		if(res != RES_OK) break;
 
 		while(offset<*romSize)
 		{
-			readByte = readCache(patch.handle, &cache, &res);
+			readByte = readCache(&patch, &cache, &res);
 			if(res != RES_OK) break;
 
 			if(readByte == 0x00)

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -35,7 +35,6 @@
 #define UPS_MAGIC_SIZE 4
 #define UPS_CRC_SIZE 4 * 3
 
-
 typedef struct
 {
 	u8 *buffer;
@@ -43,6 +42,14 @@ typedef struct
 	u16 offset;
 	u16 capacity;
 } Cache;
+
+typedef struct
+{
+	FHandle handle;
+	u32 size;
+	u32 baseRomSize;
+	u32 patchedRomSize;
+} UPSPatch;
 
 
 
@@ -148,6 +155,33 @@ static uintmax_t read_vuint(const FHandle patchFile, Result *res, Cache *cache) 
 	return result;
 }
 
+// This function expects that the first chunk of the UPS patch is cached.
+static Result loadUPSMetadata(UPSPatch *patch, Cache *cache)
+{
+	// Check magic.
+	if(memcmp("UPS1", cache->buffer, UPS_MAGIC_SIZE) != 0) return RES_INVALID_PATCH;
+	cache->offset += UPS_MAGIC_SIZE;
+
+	// Decode base and patched ROM sizes.
+	Result res = RES_OK;
+	patch->baseRomSize = (u32)read_vuint(patch->handle, &res, cache);
+	if(res != RES_OK) return res;
+
+	patch->patchedRomSize = (u32)read_vuint(patch->handle, &res, cache);
+	if(res != RES_OK) return res;
+
+	debug_printf("Base size:    0x%lx\nPatched size: 0x%lx\n", patch->baseRomSize, patch->patchedRomSize);
+
+	// Patches that would result in a ROM bigger than 32MiB are invalid.
+	if(patch->patchedRomSize > LGY_MAX_ROM_SIZE)
+	{
+		ee_puts("Patched ROM exceeds 32MiB! Skipping patching...");
+		return RES_INVALID_PATCH;
+	}
+
+	return res;
+}
+
 static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	Cache cache = {
 		(u8*)calloc(512, 1), // Buffer.
@@ -167,9 +201,16 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	}
 	patchSize -= UPS_CRC_SIZE;
 
+	UPSPatch patch = {
+		patchHandle,
+		patchSize,   // Patch file size minus CRC-32 hashes.
+		0,           // Base ROM size.
+		0            // Patched ROM size.
+	};
+
 	// Try to perform initial caching.
-	cache.size = min(cache.capacity, patchSize);
-	Result res = fRead(patchHandle, cache.buffer, cache.size, NULL);
+	cache.size = min(cache.capacity, patch.size);
+	Result res = fRead(patch.handle, cache.buffer, cache.size, NULL);
 	if(res != RES_OK)
 	{
 		free(cache.buffer);
@@ -178,59 +219,33 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 
 	ee_puts("UPS patch found! Patching...");
 
-	// Verify the patch is indeed UPS.
-	if(memcmp("UPS1", cache.buffer, UPS_MAGIC_SIZE) != 0)
-	{
-		free(cache.buffer);
-		return RES_INVALID_PATCH;
-	}
-	cache.offset += UPS_MAGIC_SIZE;
-
-	// Get unpatched and patched ROM sizes.
-	u32 baseRomSize = (u32)read_vuint(patchHandle, &res, &cache);
-	if(res != RES_OK)
+	// Validate the patch and load the metadata.
+	if((res = loadUPSMetadata(&patch, &cache)) != RES_OK)
 	{
 		free(cache.buffer);
 		return res;
-	}
-	u32 patchedRomSize = (u32)read_vuint(patchHandle, &res, &cache);
-	if(res != RES_OK)
-	{
-		free(cache.buffer);
-		return res;
-	}
-
-	debug_printf("Base size:    0x%lx\nPatched size: 0x%lx\n", baseRomSize, patchedRomSize);
-
-	// Patched ROMs greater than 32MiB are always invalid.
-	// Patches are always valid past this check.
-	if(patchedRomSize > LGY_MAX_ROM_SIZE)
-	{
-		ee_puts("Patched ROM exceeds 32MiB! Skipping patching...");
-		free(cache.buffer);
-		return RES_INVALID_PATCH;
 	}
 
 	// Scale up ROM if needed.
-	if(patchedRomSize > baseRomSize)
+	if(patch.patchedRomSize > patch.baseRomSize)
 	{
-		*romSize = nextPow2(patchedRomSize);
-		memset((char*)(LGY_ROM_LOC + baseRomSize), 0xFFu, *romSize - baseRomSize); //fill out extra rom space
-		memset((char*)(LGY_ROM_LOC + baseRomSize), 0x00u, patchedRomSize - baseRomSize); //fill new patch area with 0's
+		*romSize = nextPow2(patch.patchedRomSize);
+		memset((char*)(LGY_ROM_LOC + patch.baseRomSize), 0xFFu, *romSize - patch.baseRomSize); //fill out extra rom space
+		memset((char*)(LGY_ROM_LOC + patch.baseRomSize), 0x00u, patch.patchedRomSize - patch.baseRomSize); //fill new patch area with 0's
 	}
 
 	u32 offset = 0;
 	u8 readByte = 0;
 	u8 *romBytes = ((u8*)LGY_ROM_LOC);
 
-	while(fTell(patchHandle) < patchSize && res == RES_OK)
+	while(fTell(patch.handle) < patch.size && res == RES_OK)
 	{
-		offset += read_vuint(patchHandle, &res, &cache);
+		offset += read_vuint(patch.handle, &res, &cache);
 		if(res != RES_OK) break;
 
 		while(offset<*romSize)
 		{
-			readByte = readCache(patchHandle, &cache, &res);
+			readByte = readCache(patch.handle, &cache, &res);
 			if(res != RES_OK) break;
 
 			if(readByte == 0x00)

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -191,16 +191,16 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 
 		debug_printf("Base size:    0x%lx\nPatched size: 0x%lx\n", baseRomSize, patchedRomSize);
 
-		if(patchedRomSize > baseRomSize) {
-			//scale up rom
-			*romSize = nextPow2(patchedRomSize);
-			//check if upscaled rom is too big
-			if(*romSize > LGY_MAX_ROM_SIZE) {
-				ee_puts("Patched ROM exceeds 32MB! Skipping patching...");
-				free(cache.buffer);
-				return RES_INVALID_PATCH; 
-			}
+		// Patched ROMs greater than 32MiB are always invalid.
+		if(patchedRomSize > LGY_MAX_ROM_SIZE) {
+			ee_puts("Patched ROM exceeds 32MiB! Skipping patching...");
+			free(cache.buffer);
+			return RES_INVALID_PATCH;
+		}
 
+		// Scale up ROM if needed.
+		if(patchedRomSize > baseRomSize) {
+			*romSize = nextPow2(patchedRomSize);
 			memset((char*)(LGY_ROM_LOC + baseRomSize), 0xFFu, *romSize - baseRomSize); //fill out extra rom space
 			memset((char*)(LGY_ROM_LOC + baseRomSize), 0x00u, patchedRomSize - baseRomSize); //fill new patch area with 0's
 		}

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -73,16 +73,14 @@ static u8 elapsedSecs(const RtcTimeDate *before, const RtcTimeDate *after)
 }
 #endif
 
-static u32 loadCache(const UPSPatch *patch, Cache *cache, Result *res)
+static u16 loadCache(const UPSPatch *patch, Cache *cache, Result *res)
 {
-	u32 bytesRead = 0;
-
-	cache->offset = 0;
 	cache->size = min(cache->capacity, patch->size - cache->totalRead);
-	*res = fRead(patch->handle, cache->buffer, cache->size, &bytesRead);
-	cache->totalRead += bytesRead;
+	*res = fRead(patch->handle, cache->buffer, cache->size, NULL);
+	cache->totalRead += cache->size;  // We already computed how much will be read.
+	cache->offset = 0;
 
-	return bytesRead;
+	return cache->size;
 }
 
 static u8 readCache(const UPSPatch *patch, Cache *cache, Result *res)
@@ -283,14 +281,11 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 			u8 mask = readCache(&patch, &cache, &res);
 			if(res != RES_OK) break;
 
-			// Skip to the next block of changes if this one is over.
-			if(mask == 0x00)
-			{
-				offset++;
-				break;
-			}
 			romBytes[offset] ^= mask;
 			offset++;
+
+			// Skip to the next block of changes if this one is over.
+			if(mask == 0x00) break;
 		}
 	}
 

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -44,6 +44,7 @@ typedef struct
 	u16 size;
 	u16 offset;
 	u16 capacity;
+	u32 totalRead;
 } Cache;
 
 typedef struct
@@ -71,16 +72,24 @@ static u8 elapsedSecs(const RtcTimeDate *before, const RtcTimeDate *after)
 }
 #endif
 
+static u32 loadCache(const UPSPatch *patch, Cache *cache, Result *res)
+{
+	u32 bytesRead = 0;
+
+	cache->offset = 0;
+	cache->size = min(cache->capacity, patch->size - cache->totalRead);
+	*res = fRead(patch->handle, cache->buffer, cache->size, &bytesRead);
+	cache->totalRead += bytesRead;
+
+	return bytesRead;
+}
+
 static u8 readCache(const UPSPatch *patch, Cache *cache, Result *res)
 {
 	u8 byte = cache->buffer[cache->offset++];
 
 	// Load new block of data from patch if needed.
-	if(cache->offset >= cache->capacity) {
-		cache->size = min(cache->capacity, patch->size - fTell(patch->handle));
-		*res = fRead(patch->handle, cache->buffer, cache->size, NULL);
-		cache->offset = 0;
-	}
+	if(cache->offset >= cache->capacity) loadCache(patch, cache, res);
 
 	return byte;
 }
@@ -229,11 +238,13 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 		(u8*)calloc(512, 1),  // Buffer.
 		min(512, patch.size), // Size.
 		0,                    // Offset.
-		512                   // Capacity.
+		512,                  // Capacity.
+		0,                    // Total bytes read.
 	};
 	if(cache.buffer == NULL) return RES_OUT_OF_MEM;
 
-	Result res = fRead(patch.handle, cache.buffer, cache.size, NULL);
+	Result res;
+	loadCache(&patch, &cache, &res);
 	if(res != RES_OK)
 	{
 		free(cache.buffer);

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -167,7 +167,7 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	}
 	patchSize -= UPS_CRC_SIZE;
 
-	//read data into cache for first time
+	// Try to perform initial caching.
 	cache.cacheSize = min(cache.maxCacheSize, patchSize);
 	Result res = fRead(patchHandle, cache.buffer, cache.cacheSize, NULL);
 	if(res != RES_OK)
@@ -179,22 +179,12 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	ee_puts("UPS patch found! Patching...");
 
 	// Verify the patch is indeed UPS.
-	u8 magic[] = {'U', 'P', 'S', '1'};
-	for(u8 i = 0; i < sizeof(magic) / sizeof(magic[0]); i++)
-	{
-		u8 c = readCache(patchHandle, &cache, &res);
-		if(res != RES_OK) break;
-		if(c != magic[i])
-		{
-			res = RES_INVALID_PATCH;
-			break;
-		}
-	}
-	if(res != RES_OK)
+	if(memcmp("UPS1", cache.buffer, UPS_MAGIC_SIZE) != 0)
 	{
 		free(cache.buffer);
-		return res;
+		return RES_INVALID_PATCH;
 	}
+	cache.cacheOffset += UPS_MAGIC_SIZE;
 
 	// Get unpatched and patched ROM sizes.
 	u32 baseRomSize = (u32)read_vuint(patchHandle, &res, &cache);

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -263,8 +263,10 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	if(patch.patchedRomSize > patch.baseRomSize)
 	{
 		*romSize = nextPow2(patch.patchedRomSize);
-		memset((char*)(LGY_ROM_LOC + patch.baseRomSize), 0xFFu, *romSize - patch.baseRomSize); //fill out extra rom space
-		memset((char*)(LGY_ROM_LOC + patch.baseRomSize), 0x00u, patch.patchedRomSize - patch.baseRomSize); //fill new patch area with 0's
+		// Zero extra ROM space to be patched.
+		memset((char*)(LGY_ROM_LOC + patch.baseRomSize), 0x00, patch.patchedRomSize - patch.baseRomSize);
+		// Pad up to the end of the virtual cart.
+		memset((char*)(LGY_ROM_LOC + patch.patchedRomSize), 0xFF, *romSize - patch.patchedRomSize);
 	}
 
 	// Patch the ROM.

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -149,22 +149,19 @@ static uintmax_t read_vuint(const FHandle patchFile, Result *res, Cache *cache) 
 }
 
 static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
-	Result res = RES_OK;
-
 	Cache cache = {
 		(u8*)calloc(512, 1), //buffer
 		0,                   //cache size
 		0,                   //cache offset
 		512                  //max cache size
 	};
-	if(cache.buffer == NULL) {
-		return RES_OUT_OF_MEM;
-	}
+	if(cache.buffer == NULL) return RES_OUT_OF_MEM;
 
 	// Reject patches shorter than header + CRC hashes.
 	// Compute length minus hashes when done.
 	u32 patchSize = fSize(patchHandle);
-	if(patchSize < UPS_MAGIC_SIZE + UPS_CRC_SIZE) {
+	if(patchSize < UPS_MAGIC_SIZE + UPS_CRC_SIZE)
+	{
 		free(cache.buffer);
 		return RES_INVALID_PATCH;
 	}
@@ -172,45 +169,61 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 
 	//read data into cache for first time
 	cache.cacheSize = min(cache.maxCacheSize, patchSize);
-	res = fRead(patchHandle, cache.buffer, cache.cacheSize, NULL);
-	if(res != RES_OK) { free(cache.buffer); return res; }
+	Result res = fRead(patchHandle, cache.buffer, cache.cacheSize, NULL);
+	if(res != RES_OK)
+	{
+		free(cache.buffer);
+		return res;
+	}
 
 	ee_puts("UPS patch found! Patching...");
 
 	// Verify the patch is indeed UPS.
 	u8 magic[] = {'U', 'P', 'S', '1'};
-	for(u8 i = 0; i < sizeof(magic) / sizeof(magic[0]); i++) {
+	for(u8 i = 0; i < sizeof(magic) / sizeof(magic[0]); i++)
+	{
 		u8 c = readCache(patchHandle, &cache, &res);
 		if(res != RES_OK) break;
-		if(c != magic[i]) {
+		if(c != magic[i])
+		{
 			res = RES_INVALID_PATCH;
 			break;
 		}
 	}
-	if(res != RES_OK) {
+	if(res != RES_OK)
+	{
 		free(cache.buffer);
 		return res;
 	}
 
-	//get rom size
+	// Get unpatched and patched ROM sizes.
 	u32 baseRomSize = (u32)read_vuint(patchHandle, &res, &cache);
-	if(res != RES_OK) { free(cache.buffer); return res; }
-	//get patched rom size
+	if(res != RES_OK)
+	{
+		free(cache.buffer);
+		return res;
+	}
 	u32 patchedRomSize = (u32)read_vuint(patchHandle, &res, &cache);
-	if(res != RES_OK) { free(cache.buffer); return res; }
+	if(res != RES_OK)
+	{
+		free(cache.buffer);
+		return res;
+	}
 
 	debug_printf("Base size:    0x%lx\nPatched size: 0x%lx\n", baseRomSize, patchedRomSize);
 
 	// Patched ROMs greater than 32MiB are always invalid.
 	// Patches are always valid past this check.
-	if(patchedRomSize > LGY_MAX_ROM_SIZE) {
+	if(patchedRomSize > LGY_MAX_ROM_SIZE)
+	{
 		ee_puts("Patched ROM exceeds 32MiB! Skipping patching...");
 		free(cache.buffer);
 		return RES_INVALID_PATCH;
 	}
 
 	// Scale up ROM if needed.
-	if(patchedRomSize > baseRomSize) {
+	if(patchedRomSize > baseRomSize)
+	{
 		*romSize = nextPow2(patchedRomSize);
 		memset((char*)(LGY_ROM_LOC + baseRomSize), 0xFFu, *romSize - baseRomSize); //fill out extra rom space
 		memset((char*)(LGY_ROM_LOC + baseRomSize), 0x00u, patchedRomSize - baseRomSize); //fill new patch area with 0's
@@ -220,15 +233,18 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	u8 readByte = 0;
 	u8 *romBytes = ((u8*)LGY_ROM_LOC);
 
-	while(fTell(patchHandle) < patchSize && res == RES_OK) {
+	while(fTell(patchHandle) < patchSize && res == RES_OK)
+	{
 		offset += read_vuint(patchHandle, &res, &cache);
 		if(res != RES_OK) break;
 
-		while(offset<*romSize) {
+		while(offset<*romSize)
+		{
 			readByte = readCache(patchHandle, &cache, &res);
 			if(res != RES_OK) break;
 
-			if(readByte == 0x00) {
+			if(readByte == 0x00)
+			{
 				offset++;
 				break;
 			}
@@ -238,7 +254,6 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 	}
 
 	free(cache.buffer);
-
 	return res;
 }
 

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -35,8 +35,9 @@
 
 #define min(a, b)  ((size_t) (a) <= (size_t) (b) ? (size_t) (a) : (size_t) (b))
 
-#define UPS_MAGIC_SIZE 4
-#define UPS_CRC_SIZE 4 * 3
+#define BUFFER_CAPACITY  512
+#define UPS_MAGIC_SIZE   4
+#define UPS_CRC_SIZE     4 * 3
 
 typedef struct
 {
@@ -102,7 +103,7 @@ static bool hasDataLeft(const Cache *cache)
 static Result patchIPS(const FHandle patchHandle) {
 	ee_puts("IPS patch found! Patching...");
 
-	const u16 bufferSize = 512;
+	const u16 bufferSize = BUFFER_CAPACITY;
 	char *buffer = (char*)calloc(bufferSize, 1);
 	if(buffer == NULL) return RES_OUT_OF_MEM;
 
@@ -235,11 +236,11 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 
 	// Try to perform initial caching.
 	Cache cache = {
-		(u8*)calloc(512, 1),  // Buffer.
-		min(512, patch.size), // Size.
-		0,                    // Offset.
-		512,                  // Capacity.
-		0,                    // Total bytes read.
+		(u8*)calloc(BUFFER_CAPACITY, 1),  // Buffer.
+		min(BUFFER_CAPACITY, patch.size), // Size.
+		0,                                // Offset.
+		BUFFER_CAPACITY,                  // Capacity.
+		0,                                // Total bytes read.
 	};
 	if(cache.buffer == NULL) return RES_OUT_OF_MEM;
 

--- a/source/arm11/patch.c
+++ b/source/arm11/patch.c
@@ -237,26 +237,27 @@ static Result patchUPS(const FHandle patchHandle, u32 *romSize) {
 		memset((char*)(LGY_ROM_LOC + patch.baseRomSize), 0x00u, patch.patchedRomSize - patch.baseRomSize); //fill new patch area with 0's
 	}
 
+	// Patch the ROM.
 	u32 offset = 0;
-	u8 readByte = 0;
 	u8 *romBytes = ((u8*)LGY_ROM_LOC);
-
 	while(fTell(patch.handle) < patch.size && res == RES_OK)
 	{
 		offset += read_vuint(&patch, &res, &cache);
 		if(res != RES_OK) break;
 
-		while(offset<*romSize)
+		// Use the expected exact ROM size.
+		while(offset < patch.patchedRomSize)
 		{
-			readByte = readCache(&patch, &cache, &res);
+			u8 mask = readCache(&patch, &cache, &res);
 			if(res != RES_OK) break;
 
-			if(readByte == 0x00)
+			// Skip to the next block of changes if this one is over.
+			if(mask == 0x00)
 			{
 				offset++;
 				break;
 			}
-			romBytes[offset] ^= readByte;
+			romBytes[offset] ^= mask;
 			offset++;
 		}
 	}


### PR DESCRIPTION
This PR is meant to refactor the UPS side of ROM patching.

For every commit, I made sure that my test ROM (Mother 3) evaluated to the correct SHA-1 hash after being patched.
Later on, I found a Pokémon romhack that requires resizing of the source ROM, so that part of the logic was tested and confirmed working too. More info in the commit messages.

---

## ROMs tested

Alongside Mother 3 and the related patch, I also tested Pokémon Emerald with the Theta Emerald Renev romhack, which resizes the ROM from 16MiB to 32MiB.

Additionally, I cobbled up a handful of dummy UPS patches in GodMode9 to test edge cases such as a too short patch. The only problem I didn't correct, and which exists in your version, is that certain malformed patches might end up having you force a poweroff by holding Power, which is the main reason I marked the PR as a WIP.

Finally, in order to test whether the empty space padding works as expected for ROMs that are bigger after being patched, I manually trimmed the Emerald Renev romhack to exclude the padding data and adjusted the expected patched ROM size.
The patched OAF was able to pad the ROM and produce the correct hash, but the one from the master branch did not.

---

## Some execution metrics

Thanks to a new rudimentary timing function (which is useless if the patching would exceed 59s), I was able to confirm that the refactor marginally improved patching times.

This is more apparent the bigger the patch is (Theta Emerald Renev takes 21-23s with your debug build but 16-17s on mine) and less obvious for small patches (Mother 3 clocks in at 1-2s in yours and 1s in mine).
The timing logic is compiled out in release mode, but hacky wall-clock measurements show a 3s-ish improvement for Theta Emerald Renev.

---

## Footnotes on the UPS format

A UPS file is binary data which begins with the `UPS1` magic.

Then, two variable-length potentially infinite integers (varints) follow, and represent the source ROM size and the patched ROM size, respectively.

Afterwards there is a list of blocks, starting with a varint that contains the offset to add to our current position in the ROM and followed by the bytes to XOR with our base ROM data. The end of a block is marked with a null byte.

Finally, 12 bytes before the end of the patch, there are three CRC-32 hashes in the ZLIB CRC-32 flavor. The first is the hash of the base ROM, the second is that of the patched ROM and the last is the hash of the patch, minus the last four bytes. We are not using these at the moment, but could do so if OAF had the required CRC-32 implementation.

Closes #247.