### PR TITLE
Add Dockerfile for generating a dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM devkitpro/devkitarm
+
+RUN git clone https://github.com/profi200/dma330as && \
+    cd dma330as && \
+    make && \
+    cp dma330as /usr/local/bin/ && \
+    cd .. && \
+    git clone --depth 1 --recurse-submodules https://github.com/derrekr/ctr_firm_builder.git && \
+    cd ctr_firm_builder && \
+    make && \
+    cp firm_builder /usr/local/bin/ && \
+    cd .. && \
+    rm -rf dma330as/ ctr_firm_builder/ && \
+    apt-get install -y --no-install-recommends p7zip-full && \
+    apt-get -y autoremove --purge && \
+    apt-get -y clean


### PR DESCRIPTION
Adds a Dockerfile that can be used to generate a container suitable for building.

To build the container, run `docker build -t openagbfirm`. Then, to build, run `docker run -it --rm -v "$(pwd):/app" -w "/app" openagbfirm:latest make <TARGET>`.