### PR TITLE
Remove limits on path lengths and directory entry count

### DIFF
--- a/include/arm11/filebrowser.h
+++ b/include/arm11/filebrowser.h
@@ -27,7 +27,7 @@ extern "C"
 {
 #endif
 
-Result browseFiles(const char *const basePath, char selected[512]);
+Result browseFiles(const char *const basePath, char** selected, char** lastPath);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/source/arm11/filebrowser.c
+++ b/source/arm11/filebrowser.c
@@ -196,10 +196,8 @@ char *pathAppend(char *src, size_t *srcSize, char *dst)
 	size_t newLen = srcLen + dstLen + (addSlash ? 2 : 1);
 	if (newLen >= *srcSize)
 	{
-		char *newSrc = (char*)fcramAlloc(newLen);
+		char *newSrc = (char*)realloc(src, newLen);
 		if (!newSrc)  goto bail;
-		memcpy(newSrc, src, *srcSize);
-		fcramFree(src);
 		src = newSrc;
 		*srcSize = newLen;
 	}
@@ -209,7 +207,7 @@ char *pathAppend(char *src, size_t *srcSize, char *dst)
 	src[srcLen + dstLen] = '\0';
 	return src;
 bail:
-	fcramFree(src);
+	free(src);
 	return NULL;
 }
 
@@ -217,7 +215,7 @@ Result browseFiles(const char *const basePath, char **selected, char **lastPath)
 {
 	if(basePath == NULL || selected == NULL || lastPath == NULL) return RES_INVALID_ARG;
 
-	char *curDir = (char*)fcramAlloc(512);
+	char *curDir = (char*)malloc(512);
 	size_t curDirCapacity = 512;
 	if(curDir == NULL) return RES_OUT_OF_MEM;
 	safeStrcpy(curDir, basePath, 512);
@@ -286,7 +284,7 @@ Result browseFiles(const char *const basePath, char **selected, char **lastPath)
 
 				if(dList->entries[cursorPos].type == ENTRY_FILE)
 				{
-					char *lastPathBuf = fcramAlloc(strlen(curDir) + 1);
+					char *lastPathBuf = malloc(strlen(curDir) + 1);
 					if(!lastPathBuf)
 					{
 						res = RES_OUT_OF_MEM;
@@ -336,7 +334,7 @@ end:
 	}
 	if (curDir != NULL)
 	{
-		fcramFree(curDir);
+		free(curDir);
 	}
 	// Clear screen.
 	ee_printf("\x1b[2J");

--- a/source/arm11/filebrowser.c
+++ b/source/arm11/filebrowser.c
@@ -215,10 +215,10 @@ Result browseFiles(const char *const basePath, char **selected, char **lastPath)
 {
 	if(basePath == NULL || selected == NULL || lastPath == NULL) return RES_INVALID_ARG;
 
-	char *curDir = (char*)malloc(512);
-	size_t curDirCapacity = 512;
+	size_t curDirCapacity = strlen(basePath) + 1;
+	char *curDir = (char*)malloc(curDirCapacity);
 	if(curDir == NULL) return RES_OUT_OF_MEM;
-	safeStrcpy(curDir, basePath, 512);
+	safeStrcpy(curDir, basePath, curDirCapacity);
 
 	DirList *dList = NULL;
 	Result res;

--- a/source/arm11/filebrowser.c
+++ b/source/arm11/filebrowser.c
@@ -109,7 +109,10 @@ int dlistCompare(const void *a, const void *b)
 static Result scanDir(const char *const path, const char *const filter, DirList **dListOut)
 {
     if(dListOut == NULL) return RES_INVALID_ARG;
-    if(*dListOut != NULL) fcramFree(*dlistOut); // handle freeing old one
+    if(*dListOut != NULL) {
+        fcramFree(*dlistOut);
+        *dlistOut = NULL;
+    }
 	FILINFO *const fis = (FILINFO*)fcramAlloc(sizeof(FILINFO) * DIR_READ_BLOCKS);
 	if(fis == NULL) return RES_OUT_OF_MEM;
 	DirList *dList = dlistNew();

--- a/source/arm11/filebrowser.c
+++ b/source/arm11/filebrowser.c
@@ -294,7 +294,7 @@ Result browseFiles(const char *const basePath, char **selected, char **lastPath)
 					curDir = pathAppend(curDir, &curDirCapacity, dList->entries[cursorPos].name);
 					if (!curDir)
 					{
-						fcramFree(lastPathBuf);
+						free(lastPathBuf);
 						res = RES_OUT_OF_MEM;
 						goto end;
 					}

--- a/source/arm11/filebrowser.c
+++ b/source/arm11/filebrowser.c
@@ -108,6 +108,8 @@ int dlistCompare(const void *a, const void *b)
 
 static Result scanDir(const char *const path, const char *const filter, DirList **dListOut)
 {
+    if(dListOut == NULL) return RES_INVALID_ARG;
+    if(*dListOut != NULL) fcramFree(*dlistOut); // handle freeing old one
 	FILINFO *const fis = (FILINFO*)fcramAlloc(sizeof(FILINFO) * DIR_READ_BLOCKS);
 	if(fis == NULL) return RES_OUT_OF_MEM;
 	DirList *dList = dlistNew();

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -320,7 +320,7 @@ Result oafInitAndRun(void)
 		if(res == RES_FR_NO_FILE)
 		{
 			res = showFileBrowser(&romFilePath);
-			if(res != RES_OK || *romFilePath == '\0') break;
+			if(res != RES_OK || !romFilePath || *romFilePath == '\0') break;
 			ee_puts("Loading...");
 		}
 		else if(res != RES_OK) break;


### PR DESCRIPTION
Removes the hard-coded limits on path lengths and maximum number of files in a directory.

This allows arbitrarily-long filenames to be loaded, as well as long paths to be saved as the last path. In addition, it removes the 1000 file limit and allows for loading directories of arbitrary size.