### PR TITLE
arm11: Add battery and system time display on the bottom screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ X+LEFT - Turn off LCD backlight.
 
 X+RIGHT - Turn on LCD backlight.
 
+Y+Touch - Toggle bottom screen backlight to show battery level and system time.
+
 Hold the X button while launching a game to skip applying patches (if present)
 
 Hold the power button to turn off the 3DS.

--- a/source/arm11/oaf_video.c
+++ b/source/arm11/oaf_video.c
@@ -444,10 +444,13 @@ static KHandle setupFrameCapture(const u8 scaler, const bool colorCorrectionEnab
 
 KHandle OAF_videoInit(void)
 {
-	// Don't force black and turn the backlight off on the bottom screen.
+	// Don't force black on the bottom screen.
 	GFX_setForceBlack(false, false);
+
+	// Turn off the backlight on the bottom screen by default.
+	// It can be toggled on later during gameplay.
 	if(MCU_getSystemModel() != SYS_MODEL_2DS)
-		GFX_powerOnBacklight(GFX_BL_BOT);
+		GFX_powerOffBacklight(GFX_BL_BOT);
 
 	// Initialize frame capture.
 	const u8 scaler = g_oafConfig.scaler;

--- a/source/arm11/oaf_video.c
+++ b/source/arm11/oaf_video.c
@@ -444,13 +444,10 @@ static KHandle setupFrameCapture(const u8 scaler, const bool colorCorrectionEnab
 
 KHandle OAF_videoInit(void)
 {
-#ifdef NDEBUG
-	// Force black and turn the backlight off on the bottom screen.
-	// Don't turn the backlight off on 2DS (1 panel).
-	GFX_setForceBlack(false, true);
+	// Don't force black and turn the backlight off on the bottom screen.
+	GFX_setForceBlack(false, false);
 	if(MCU_getSystemModel() != SYS_MODEL_2DS)
-		GFX_powerOffBacklight(GFX_BL_BOT);
-#endif
+		GFX_powerOnBacklight(GFX_BL_BOT);
 
 	// Initialize frame capture.
 	const u8 scaler = g_oafConfig.scaler;

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -354,15 +354,15 @@ Result oafInitAndRun(void)
 }
 
 static bool g_botBacklightOn = false;
+static u32 g_statsFrameCount = 0;
 
 static void updateStats(void)
 {
 	if(!g_botBacklightOn) return;
 
-	static u32 frameCount = 0;
-	if(frameCount % 600 != 0)
+	if(g_statsFrameCount % 600 != 0)
 	{
-		frameCount++;
+		g_statsFrameCount++;
 		return;
 	}
 
@@ -374,7 +374,7 @@ static void updateStats(void)
 	int hour = (td.hour / 16 * 10) + (td.hour % 16);
 	int min = (td.min / 16 * 10) + (td.min % 16);
 
-	if(frameCount == 0)
+	if(g_statsFrameCount == 0)
 	{
 		ee_printf("Y + Touch: Toggle bottom screen\n");
 	}
@@ -387,7 +387,7 @@ static void updateStats(void)
 	ee_printf("Time: %02d:%02d\nBattery: %3d%%", hour, min, battery);
 	GFX_flushBuffers();
 
-	frameCount++;
+	g_statsFrameCount++;
 }
 
 void oafUpdate(void)
@@ -407,8 +407,13 @@ void oafUpdate(void)
 	if(kDown == KEY_TOUCH && kHeld == (KEY_Y | KEY_TOUCH))
 	{
 		g_botBacklightOn = !g_botBacklightOn;
-		if(g_botBacklightOn) GFX_powerOnBacklight(GFX_BL_BOT);
-		else                 GFX_powerOffBacklight(GFX_BL_BOT);
+		if(g_botBacklightOn)
+		{
+			GFX_powerOnBacklight(GFX_BL_BOT);
+			if(g_statsFrameCount % 600 != 0)
+				g_statsFrameCount = (g_statsFrameCount / 600 + 1) * 600;
+		}
+		else GFX_powerOffBacklight(GFX_BL_BOT);
 	}
 
 	CODEC_runHeadphoneDetection();

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -18,6 +18,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include "types.h"
 #include "util.h"
 #include "arm11/fast_rom_padding.h"
@@ -36,6 +37,7 @@
 #include "drivers/lgy_common.h"
 #include "arm11/oaf_video.h"
 #include "arm11/drivers/lgy11.h"
+#include "arm11/console.h"
 #include "kernel.h"
 #include "kevent.h"
 
@@ -351,6 +353,32 @@ Result oafInitAndRun(void)
 	return res;
 }
 
+static void updateStats(void)
+{
+	static u32 frameCount = 0;
+	if(frameCount % 600 != 0)
+	{
+		frameCount++;
+		return;
+	}
+
+	u8 battery = MCU_getBatteryLevel();
+	RtcTimeDate td;
+	MCU_getRtcTimeDate(&td);
+
+	// Convert BCD to decimal.
+	int hour = (td.hour / 16 * 10) + (td.hour % 16);
+	int min = (td.min / 16 * 10) + (td.min % 16);
+
+	// If this isn't the first print, move the cursor up 1 line to the start of the stats block.
+	if(frameCount > 0) ee_printf("\x1b[A\r");
+
+	ee_printf("Time: %02d:%02d\nBattery: %3d%%", hour, min, battery);
+	GFX_flushBuffers();
+
+	frameCount++;
+}
+
 void oafUpdate(void)
 {
 	const u32 *const maps = g_oafConfig.buttonMaps;
@@ -365,6 +393,7 @@ void oafUpdate(void)
 
 	CODEC_runHeadphoneDetection();
 	updateBacklight();
+	updateStats();
 	waitForEvent(g_frameReadyEvent);
 	clearEvent(g_frameReadyEvent);
 }

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -353,8 +353,12 @@ Result oafInitAndRun(void)
 	return res;
 }
 
+static bool g_botBacklightOn = true;
+
 static void updateStats(void)
 {
+	if(!g_botBacklightOn) return;
+
 	static u32 frameCount = 0;
 	if(frameCount % 600 != 0)
 	{
@@ -383,6 +387,7 @@ void oafUpdate(void)
 {
 	const u32 *const maps = g_oafConfig.buttonMaps;
 	const u32 kHeld = hidKeysHeld();
+	const u32 kDown = hidKeysDown();
 	u16 pressed = 0;
 	for(unsigned i = 0; i < 10; i++)
 	{
@@ -390,6 +395,14 @@ void oafUpdate(void)
 			pressed |= 1u<<i;
 	}
 	LGY11_setInputState(pressed);
+
+	// Toggle bottom screen backlight with Y + TOUCH.
+	if(kDown == KEY_TOUCH && kHeld == (KEY_Y | KEY_TOUCH))
+	{
+		g_botBacklightOn = !g_botBacklightOn;
+		if(g_botBacklightOn) GFX_powerOnBacklight(GFX_BL_BOT);
+		else                 GFX_powerOffBacklight(GFX_BL_BOT);
+	}
 
 	CODEC_runHeadphoneDetection();
 	updateBacklight();

--- a/source/arm11/open_agb_firm.c
+++ b/source/arm11/open_agb_firm.c
@@ -353,7 +353,7 @@ Result oafInitAndRun(void)
 	return res;
 }
 
-static bool g_botBacklightOn = true;
+static bool g_botBacklightOn = false;
 
 static void updateStats(void)
 {
@@ -374,8 +374,15 @@ static void updateStats(void)
 	int hour = (td.hour / 16 * 10) + (td.hour % 16);
 	int min = (td.min / 16 * 10) + (td.min % 16);
 
-	// If this isn't the first print, move the cursor up 1 line to the start of the stats block.
-	if(frameCount > 0) ee_printf("\x1b[A\r");
+	if(frameCount == 0)
+	{
+		ee_printf("Y + Touch: Toggle bottom screen\n");
+	}
+	else
+	{
+		// Move up 1 line to the start of the stats block (Time line).
+		ee_printf("\x1b[A\r");
+	}
 
 	ee_printf("Time: %02d:%02d\nBattery: %3d%%", hour, min, battery);
 	GFX_flushBuffers();


### PR DESCRIPTION
# arm11: Add battery and system time display on the bottom screen

## Summary
This PR adds the ability to display the current system time and battery percentage on the bottom screen during GBA gameplay.

## Features
- **Independent Toggle**: Use the hotkey `Y + TOUCH` to toggle the bottom screen backlight and statistics display on or off at any time.
- **Power Efficient**:
    - The bottom screen is **off by default** to preserve battery life and maintain the original project behavior.
    - Statistics are refreshed approximately every 10 seconds (600 frames) to minimize I2C traffic to the MCU.
    - Processing (I2C reads and console printing) is entirely suspended when the bottom screen is toggled off.
- **Clean UI**:
    - Uses in-place console updates (`\r`, `\x1b[A`) to ensure the stats stay pinned to the same lines without scrolling.
    - Includes a concise on-screen hint (`Y + Touch: Toggle bottom screen`) the first time the display is activated to ensure the feature is discoverable.
- **Documented**: Added the new hotkey to the `Controls` section of the `README.md`.

## Rationale
While `open_agb_firm` provides an excellent native GBA experience, users currently have no way to check the time or battery level without rebooting the console. This implementation provides that essential information while strictly prioritizing power efficiency and maintaining a clean, unobtrusive interface.

## How to Test
1. Launch `open_agb_firm` and select any GBA ROM.
2. The bottom screen will remain off by default.
3. Hold `Y` and touch the bottom screen to reveal the stats and the toggle hint.
4. Verify the stats refresh every 10 seconds.
5. Toggle the display off again with `Y + TOUCH`.