### PR TITLE
Fix parallel building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,20 +30,12 @@ export VERS_MINOR  := $(shell echo "$(VERS_STRING)" | sed 's/.*\.\([0-9]*\).*/\1
 NPROC := $(shell nproc)
 
 
-.PHONY: checkarm9 checkarm11 clean release
+.PHONY: clean release
 
 #---------------------------------------------------------------------------------
 # main targets
 #---------------------------------------------------------------------------------
-all: checkarm9 checkarm11 $(TARGET).firm
-
-#---------------------------------------------------------------------------------
-checkarm9:
-	@$(MAKE) -j$(NPROC) --no-print-directory -C arm9
-
-#---------------------------------------------------------------------------------
-checkarm11:
-	@$(MAKE) -j$(NPROC) --no-print-directory -C arm11
+all: $(TARGET).firm
 
 #---------------------------------------------------------------------------------
 $(TARGET).firm: arm9/$(TARGET)9.bin arm11/$(TARGET)11.bin


### PR DESCRIPTION
The `checkarm` targets were being built alongside `$(TARGET).firm`,
which caused the .bin files to be built twice, once per `checkarm` and
once as part of the `$(TARGET).firm)` dependencies.

Moreover, with enough (in my case 4) jobs spawned in parallel, a race
condition could trigger where the same .bin file and related
dependencies was built by two jobs, leading to failure.

The original issue can be reproduced intermittently with `make clean && make -j4`
in the unpatched Makefile.
