### PR TITLE
Adding a fullscreen scaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Video-related settings.
 
 `string scaler` - Video scaler.
 * Default: `matrix`
-* Options: `none`, `bilinear`, `matrix`
+* Options: `none`, `bilinear`, `matrix`, `stretch`
+  * `stretch` uses the matrix scaler and stretches the resulting 360x240 image horizontally to fill the complete 400x240 top screen. This changes the original GBA aspect ratio.
 
 `string colorProfile` - Color correction profile.
 * Default: `none`

--- a/include/arm11/config.h
+++ b/include/arm11/config.h
@@ -42,7 +42,7 @@ typedef struct
 	bool useSavesFolder;
 
 	// [video]
-	u8 scaler;          // 0 = 1:1/none, 1 = bilinear (GPU) x1.5, 2 = matrix (hardware) x1.5.
+	u8 scaler;          // 0 = 1:1/none, 1 = bilinear (GPU) x1.5, 2 = matrix (hardware) x1.5, 3 = matrix stretch.
 	u8 colorProfile;    // 0 = none, 1 = GBA, 2 = GB micro, 3 = GBA SP (AGS-101), 4 = DS phat, 5 = DS lite, 6 = Nintendo Switch Online, 7 = Visual Boy Advance/No$GBA, 8 = identity.
 	float contrast;     // Range 0.0-1.0.
 	float brightness;   // Range 0.0-1.0.

--- a/source/arm11/config.c
+++ b/source/arm11/config.c
@@ -159,6 +159,8 @@ static int cfgIniCallback(void *user, const char *section, const char *name, con
 				config->scaler = 1;
 			else if(strcmp(value, "matrix") == 0)
 				config->scaler = 2;
+			else if(strcmp(value, "stretch") == 0)
+				config->scaler = 3;
 		}
 		else if(strcmp(name, "colorProfile") == 0)
 		{

--- a/source/arm11/gpu_cmd_lists.c
+++ b/source/arm11/gpu_cmd_lists.c
@@ -223,6 +223,24 @@ void patchGbaGpuCmdList(const u8 scaleType, const bool useSecondTexture)
 		memcpy(&gbaGpuList2[316], &tmp, 4);
 		memcpy(&gbaGpuList2[380], &tmp, 4);
 	}
+	else if(scaleType == 3)
+	{
+		// Stretch the matrix-scaled 360x240 image horizontally to the full
+		// 400x240 top-screen framebuffer. The vertex attributes use PICA200
+		// float24 values stored as three little-endian bytes.
+		const u32 xLeft  = 0x000000; //   0.0f
+		const u32 xRight = 0x479000; // 400.0f
+
+		memcpy(&gbaGpuInitList[956],  &xLeft,  3);
+		memcpy(&gbaGpuInitList[988],  &xRight, 3);
+		memcpy(&gbaGpuInitList[1020], &xLeft,  3);
+		memcpy(&gbaGpuInitList[1052], &xRight, 3);
+
+		memcpy(&gbaGpuList2[268], &xLeft,  3);
+		memcpy(&gbaGpuList2[300], &xRight, 3);
+		memcpy(&gbaGpuList2[332], &xLeft,  3);
+		memcpy(&gbaGpuList2[364], &xRight, 3);
+	}
 	// else nothing to do.
 
 	flushDCacheRange(gbaGpuInitList, sizeof(gbaGpuInitList));


### PR DESCRIPTION
This adds a fullscreen "stretch" scaler to the video options in the config.

It stretches the matrix-scaled 360x240 image horizontally to the full 400x240 top-screen framebuffer. Honestly it looks really nice and i personally don't mind the altered aspect ratio.

I tested this on my own New3DS. It works as intended.

<img width="4032" height="3024" alt="IMG_2287" src="https://github.com/user-attachments/assets/6e69f87b-ca05-4127-a77b-ff33a425644d" />